### PR TITLE
Update build tests for new go version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.14.x', '1.15.x']
+        go-version: ['1.15.x', '1.16.x']
         include:
-          - go-version: '1.15.x'
+          - go-version: '1.16.x'
             build-coverage: true
     steps:
       - name: Set up Go


### PR DESCRIPTION
There's a new go version (1.16). Update the tests to support the current and penultimate go versions.