### PR TITLE
handle blank lines in the input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.1 (2021-09-14)
+
+* Handle empty lines in the CLI tool
+
 ## 0.1.0 (2020-12-06)
 
 * Initial beta release

--- a/cmd/routesum/main.go
+++ b/cmd/routesum/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -62,9 +63,13 @@ func setupIOAndSummarize(inputPath, outputPath string) error {
 
 func summarize(in io.Reader, out io.StringWriter) error {
 	scanner := bufio.NewScanner(in)
-	lines := []string{}
+	var lines []string
 	for scanner.Scan() {
-		lines = append(lines, scanner.Text())
+		line := bytes.TrimSpace(scanner.Bytes())
+		if len(line) == 0 {
+			continue
+		}
+		lines = append(lines, string(line))
 	}
 
 	summarized, err := routesum.Strings(lines)


### PR DESCRIPTION
it looks like the goreleaser config might need udpating to handle more recent versions, because that isn't working on my machine.  But I can build and run this with `go build -o . -v ./...`