### PR TITLE
os & io are preferred over io/ioutil since 1.16

### DIFF
--- a/cmd/routesum/args_test.go
+++ b/cmd/routesum/args_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,14 +17,14 @@ func TestArgs(t *testing.T) {
 	assert.Equal(t, "-", args.outputPath, "default outputPath")
 
 	// specified values are respected
-	tempdir, err := ioutil.TempDir("", "routesum-test-")
+	tempdir, err := os.MkdirTemp("", "routesum-test-")
 	require.NoError(t, err, "create temp directory")
 	defer func() {
 		err := os.RemoveAll(tempdir)
 		require.NoError(t, err, "remove temp directory")
 	}()
 	inPath := filepath.Join(tempdir, "in.txt")
-	err = ioutil.WriteFile(inPath, []byte("192.0.2.0\n192.0.2.1\n"), 0o644)
+	err = os.WriteFile(inPath, []byte("192.0.2.0\n192.0.2.1\n"), 0o644)
 	require.NoError(t, err, "write to temp input file")
 
 	args, err = _parseArgs([]string{


### PR DESCRIPTION
[As of Go 1.16, the functionality of io/ioutil is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.](https://pkg.go.dev/io/ioutil#TempDir)