### PR TITLE
Make it easier for a computer to read

### DIFF
--- a/cmd/routesum/main.go
+++ b/cmd/routesum/main.go
@@ -10,9 +10,6 @@ import (
 	"runtime"
 
 	"github.com/PatrickCronin/routesum/pkg/routesum"
-
-	"golang.org/x/text/language"
-	"golang.org/x/text/message"
 )
 
 func main() {
@@ -36,7 +33,7 @@ func main() {
 
 func summarize(in io.Reader, out, memStatsOut io.Writer) error {
 	if memStatsOut != nil {
-		logMemStats(memStatsOut, "Before work")
+		logMemStats(memStatsOut, "Before Summarize")
 	}
 
 	rs := routesum.NewRouteSum()
@@ -53,7 +50,7 @@ func summarize(in io.Reader, out, memStatsOut io.Writer) error {
 	}
 
 	if memStatsOut != nil {
-		logMemStats(memStatsOut, "After building the summary")
+		logMemStats(memStatsOut, "After Summarize")
 	}
 
 	for _, s := range rs.SummaryStrings() {
@@ -63,7 +60,7 @@ func summarize(in io.Reader, out, memStatsOut io.Writer) error {
 	}
 
 	if memStatsOut != nil {
-		logMemStats(memStatsOut, "After writing the summary")
+		logMemStats(memStatsOut, "After Writing")
 	}
 
 	return nil
@@ -76,37 +73,15 @@ func logMemStats(w io.Writer, message string) {
 	fmt.Fprintf(
 		w,
 		`%s
-  HeapAlloc (excludes freed mem):   %s
-  TotalAlloc (includes freed mem):  %s
-  Mallocs (included freed objects): %s
-  Freed objects:                    %s
+  HeapAlloc (excludes freed mem):   %d
+  TotalAlloc (includes freed mem):  %d
+  Mallocs (included freed objects): %d
+  Freed objects:                    %d
 `,
 		message,
-		formatByteCount(int64(m.HeapAlloc)),
-		formatByteCount(int64(m.TotalAlloc)),
-		formatNumber(m.Mallocs),
-		formatNumber(m.Frees),
+		m.HeapAlloc,
+		m.TotalAlloc,
+		m.Mallocs,
+		m.Frees,
 	)
-}
-
-func formatByteCount(b int64) string {
-	const unit = 1024
-
-	if b < unit {
-		return fmt.Sprintf("%d B", b)
-	}
-
-	div := int64(unit)
-	exp := 0
-	for n := b / unit; n >= unit; n /= unit {
-		div *= unit
-		exp++
-	}
-
-	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGTPE"[exp])
-}
-
-func formatNumber(n interface{}) string {
-	p := message.NewPrinter(language.English)
-	return p.Sprintf("%d", n)
 }

--- a/cmd/routesum/main_test.go
+++ b/cmd/routesum/main_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"io"
 	"regexp"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -26,7 +25,7 @@ func TestSummarize(t *testing.T) {
 			name:         "with memory statistics",
 			showMemStats: true,
 			expected: regexp.MustCompile(
-				`Before work(?:.|\n)+After building the summary(?:.|\n)+After writing the summary`,
+				`Before Summarize(?:.|\n)+After Summarize(?:.|\n)+After Writing`,
 			),
 		},
 	}
@@ -49,58 +48,6 @@ func TestSummarize(t *testing.T) {
 
 			assert.Equal(t, "192.0.2.0/31\n", out.String(), "read expected output")
 			assert.Regexp(t, test.expected, memStatsBuilder.String(), "read expected memory stats")
-		})
-	}
-}
-
-func TestFormatByteCount(t *testing.T) {
-	tests := []struct {
-		value    int64
-		expected string
-	}{
-		{
-			value:    82,
-			expected: "82 B",
-		},
-		{
-			value:    1024,
-			expected: "1.0 KB",
-		},
-		{
-			value:    2000000,
-			expected: "1.9 MB",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(strconv.FormatInt(test.value, 10), func(t *testing.T) {
-			assert.Equal(t, test.expected, formatByteCount(test.value))
-		})
-	}
-}
-
-func TestFormatNumber(t *testing.T) {
-	tests := []struct {
-		value    uint64
-		expected string
-	}{
-		{
-			value:    82,
-			expected: "82",
-		},
-		{
-			value:    1024,
-			expected: "1,024",
-		},
-		{
-			value:    1234567890,
-			expected: "1,234,567,890",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(strconv.FormatUint(test.value, 10), func(t *testing.T) {
-			assert.Equal(t, test.expected, formatNumber(test.value))
 		})
 	}
 }


### PR DESCRIPTION
The goal is to allow a computer to parse the values simply, to make performance benchmarking over many runs simple.