### PR TITLE
Improve memory reporting

### DIFF
--- a/cmd/routesum/main_test.go
+++ b/cmd/routesum/main_test.go
@@ -24,9 +24,7 @@ func TestSummarize(t *testing.T) {
 		{
 			name:         "with memory statistics",
 			showMemStats: true,
-			expected: regexp.MustCompile(
-				`Before Summarize(?:.|\n)+After Summarize(?:.|\n)+After Writing`,
-			),
+			expected:     regexp.MustCompile(`To Store Routes(?:.|\n)+To Write Summary`),
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,5 @@ go 1.16
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0
-	golang.org/x/text v0.3.7
 	inet.af/netaddr v0.0.0-20210721214506-ce7a8ad02cc1
 )

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,6 @@ golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
-golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=


### PR DESCRIPTION
Since the goal is to evaluate memory needs of the program when building and writing the summary (separately), we change the stats being reported to display information relating to each of these steps (separately).