### PR TITLE
Replace inet.af/netaddr with net/netip

### DIFF
--- a/pkg/routesum/bitslice/bitslice_test.go
+++ b/pkg/routesum/bitslice/bitslice_test.go
@@ -1,9 +1,8 @@
 package bitslice
 
 import (
+	"net/netip"
 	"testing"
-
-	"inet.af/netaddr"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -73,7 +72,7 @@ func TestNewBitSliceFromBytes(t *testing.T) { //nolint: funlen
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ip := netaddr.MustParseIP(test.ip)
+			ip := netip.MustParseAddr(test.ip)
 			ipBytes, err := ip.MarshalBinary()
 			require.NoError(t, err)
 

--- a/pkg/routesum/routesum_test.go
+++ b/pkg/routesum/routesum_test.go
@@ -18,7 +18,7 @@ func TestStrings(t *testing.T) { //nolint: funlen
 		"2001:db8:",
 		"not an IP",
 	}
-	invalidIPErr := regexp.MustCompile(`ParseIP`)
+	invalidIPErr := regexp.MustCompile(`ParseAddr`)
 	for _, invalidIP := range invalidIPs {
 		t.Run(invalidIP, func(t *testing.T) {
 			rs := NewRouteSum()
@@ -40,7 +40,7 @@ func TestStrings(t *testing.T) { //nolint: funlen
 		"2001:db8::/129",
 		"not/a/network",
 	}
-	invalidNetErr := regexp.MustCompile(`ParseIPPrefix`)
+	invalidNetErr := regexp.MustCompile(`ParsePrefix`)
 	for _, invalidNet := range invalidNets {
 		t.Run(invalidNet, func(t *testing.T) {
 			rs := NewRouteSum()

--- a/pkg/routesum/rstrie/rstrie_test.go
+++ b/pkg/routesum/rstrie/rstrie_test.go
@@ -1,12 +1,12 @@
 package rstrie
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/PatrickCronin/routesum/pkg/routesum/bitslice"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"inet.af/netaddr"
 )
 
 func TestCommonPrefixLen(t *testing.T) {
@@ -272,7 +272,7 @@ func TestRSTrieMemUsage(t *testing.T) {
 			trie := NewRSTrie()
 
 			for _, entry := range test.entries {
-				ip := netaddr.MustParseIP(entry)
+				ip := netip.MustParseAddr(entry)
 				ipBytes, err := ip.MarshalBinary()
 				require.NoError(t, err)
 				ipBits, err := bitslice.NewFromBytes(ipBytes)


### PR DESCRIPTION
inet.af/netaddr is deprecated in favor of the new net/netip package.