### PR TITLE
Facilitate reporting internal structure metrics

### DIFF
--- a/cmd/routesum/main_test.go
+++ b/cmd/routesum/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -9,12 +11,42 @@ import (
 )
 
 func TestSummarize(t *testing.T) {
+	tests := []struct {
+		name         string
+		showMemStats bool
+		expected     *regexp.Regexp
+	}{
+		{
+			name:         "without memory statistics",
+			showMemStats: false,
+			expected:     regexp.MustCompile(`^$`),
+		},
+		{
+			name:         "with memory statistics",
+			showMemStats: true,
+			expected:     regexp.MustCompile(`Num internal nodes`),
+		},
+	}
+
 	inStr := "\n192.0.2.0\n192.0.2.1\n"
-	in := strings.NewReader(inStr)
-	var out strings.Builder
 
-	err := summarize(in, &out, nil, nil)
-	require.NoError(t, err, "summarize does not throw an error")
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			in := strings.NewReader(inStr)
+			var out strings.Builder
 
-	assert.Equal(t, "192.0.2.0/31\n", out.String(), "read expected output")
+			var memStatsBuilder strings.Builder
+			var memStatsOut io.Writer
+
+			if test.showMemStats {
+				memStatsOut = &memStatsBuilder
+			}
+
+			err := summarize(in, &out, memStatsOut, nil, nil)
+			require.NoError(t, err, "summarize does not throw an error")
+
+			assert.Equal(t, "192.0.2.0/31\n", out.String(), "read expected output")
+			assert.Regexp(t, test.expected, memStatsBuilder.String(), "read expected memory stats")
+		})
+	}
 }

--- a/pkg/routesum/routesum.go
+++ b/pkg/routesum/routesum.go
@@ -142,3 +142,13 @@ func ipv6FromBits(bits bitslice.BitSlice) netaddr.IP {
 	copy(byteArray[:], bytes[0:16])
 	return netaddr.IPv6Raw(byteArray)
 }
+
+// MemUsage provides information about memory usage.
+func (rs *RouteSum) MemUsage() (uint, uint, uintptr, uintptr) {
+	ipv4NumInternalNodes, ipv4NumLeafNodes, ipv4InternalNodesTotalSize, ipv4LeafNodesTotalSize := rs.ipv4.MemUsage()
+	ipv6NumInternalNodes, ipv6NumLeafNodes, ipv6InternalNodesTotalSize, ipv6LeafNodesTotalSize := rs.ipv6.MemUsage()
+	return ipv4NumInternalNodes + ipv6NumInternalNodes,
+		ipv4NumLeafNodes + ipv6NumLeafNodes,
+		ipv4InternalNodesTotalSize + ipv6InternalNodesTotalSize,
+		ipv4LeafNodesTotalSize + ipv6LeafNodesTotalSize
+}

--- a/pkg/routesum/rstrie/rstrie.go
+++ b/pkg/routesum/rstrie/rstrie.go
@@ -4,6 +4,7 @@ package rstrie
 import (
 	"bytes"
 	"container/list"
+	"unsafe"
 
 	"github.com/PatrickCronin/routesum/pkg/routesum/bitslice"
 )
@@ -215,4 +216,62 @@ func (t *RSTrie) Contents() []bitslice.BitSlice {
 	}
 
 	return contents
+}
+
+func (t *RSTrie) visitAll(cb func(*node)) {
+	// If the trie is empty
+	if t.root == nil {
+		return
+	}
+
+	// Otherwise
+	remainingSteps := list.New()
+	remainingSteps.PushFront(traversalStep{
+		n:                  t.root,
+		precedingRouteBits: bitslice.BitSlice{},
+	})
+
+	for remainingSteps.Len() > 0 {
+		curNode := remainingSteps.Remove(remainingSteps.Front()).(traversalStep)
+
+		// Act on this node
+		cb(curNode.n)
+
+		// Traverse the remainder of the nodes
+		if !curNode.n.isLeaf() {
+			curNodeRouteBits := bitslice.BitSlice{}
+			curNodeRouteBits = append(curNodeRouteBits, curNode.precedingRouteBits...)
+			curNodeRouteBits = append(curNodeRouteBits, curNode.n.bits...)
+
+			remainingSteps.PushFront(traversalStep{
+				n:                  curNode.n.children[1],
+				precedingRouteBits: curNodeRouteBits,
+			})
+			remainingSteps.PushFront(traversalStep{
+				n:                  curNode.n.children[0],
+				precedingRouteBits: curNodeRouteBits,
+			})
+		}
+	}
+}
+
+// MemUsage returns information about an RSTrie's current size in memory.
+func (t *RSTrie) MemUsage() (uint, uint, uintptr, uintptr) {
+	var numInternalNodes, numLeafNodes uint
+	var internalNodesTotalSize, leafNodesTotalSize uintptr
+
+	tallyNode := func(n *node) {
+		baseNodeSize := unsafe.Sizeof(node{}) + uintptr(cap(n.bits))*unsafe.Sizeof([1]byte{}) //nolint: exhaustruct, gosec, lll
+		if n.isLeaf() {
+			numLeafNodes++
+			leafNodesTotalSize += baseNodeSize
+			return
+		}
+
+		numInternalNodes++
+		internalNodesTotalSize += baseNodeSize + unsafe.Sizeof([2]*node{}) //nolint: gosec
+	}
+	t.visitAll(tallyNode)
+
+	return numInternalNodes, numLeafNodes, internalNodesTotalSize, leafNodesTotalSize
 }

--- a/pkg/routesum/rstrie/rstrie_test.go
+++ b/pkg/routesum/rstrie/rstrie_test.go
@@ -1,10 +1,12 @@
 package rstrie
 
 import (
+	"net/netip"
 	"testing"
 
 	"github.com/PatrickCronin/routesum/pkg/routesum/bitslice"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommonPrefixLen(t *testing.T) {
@@ -221,6 +223,66 @@ func TestRSTrieContents(t *testing.T) { //nolint: funlen
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, test.expected, test.trie.Contents(), "got expected bits")
+		})
+	}
+}
+
+func TestRSTrieMemUsage(t *testing.T) {
+	tests := []struct {
+		name                     string
+		entries                  []string
+		expectedNumInternalNodes uint
+		expectedNumLeafNodes     uint
+	}{
+		{
+			name:                     "new trie",
+			expectedNumInternalNodes: 0,
+			expectedNumLeafNodes:     0,
+		},
+		{
+			name: "one item",
+			entries: []string{
+				"192.0.2.1",
+			},
+			expectedNumInternalNodes: 0,
+			expectedNumLeafNodes:     1,
+		},
+		{
+			name: "two items, summarized",
+			entries: []string{
+				"192.0.2.1",
+				"192.0.2.0",
+			},
+			expectedNumInternalNodes: 0,
+			expectedNumLeafNodes:     1,
+		},
+		{
+			name: "two items, unsummarized",
+			entries: []string{
+				"192.0.2.1",
+				"192.0.2.2",
+			},
+			expectedNumInternalNodes: 1,
+			expectedNumLeafNodes:     2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			trie := NewRSTrie()
+
+			for _, entry := range test.entries {
+				ip := netip.MustParseAddr(entry)
+				ipBytes, err := ip.MarshalBinary()
+				require.NoError(t, err)
+				ipBits, err := bitslice.NewFromBytes(ipBytes)
+				require.NoError(t, err)
+				trie.InsertRoute(ipBits)
+			}
+
+			numInternalNodes, numLeafNodes, _, _ := trie.MemUsage()
+			assert.Equal(t, test.expectedNumInternalNodes, numInternalNodes, "num internal nodes")
+			assert.Equal(t, test.expectedNumLeafNodes, numLeafNodes, "num leaf nodes")
 		})
 	}
 }


### PR DESCRIPTION
Support reporting the number of internal nodes and leaf nodes, as well as their sizes.