### PR TITLE
Preallocate the visited nodes slice

### DIFF
--- a/pkg/routesum/rstrie/rstrie.go
+++ b/pkg/routesum/rstrie/rstrie.go
@@ -43,7 +43,7 @@ func (t *RSTrie) InsertRoute(routeBits bitslice.BitSlice) {
 	}
 
 	// Otherwise, perform a non-recursive search of the trie's nodes for the best place to insert the route, and do so.
-	visited := []*node{}
+	visited := make([]*node, 0, 128)
 	curNode := t.root
 	remainingRouteBits := routeBits
 


### PR DESCRIPTION
CPU profiling has shown that InsertRoute uses an absolutely surprising amount of time adding the current node to the list of nodes it has visited. In this branch, we simply preallocate the visited nodes slice, which on the face seems nuts, but in profiling shows a marked improvement in performance of the function.