### PR TITLE
Preallocate space for remembering visited nodes

### DIFF
--- a/pkg/routesum/rstrie/rstrie.go
+++ b/pkg/routesum/rstrie/rstrie.go
@@ -42,7 +42,7 @@ func (t *RSTrie) InsertRoute(routeBits bitslice.BitSlice) {
 	}
 
 	// Otherwise, perform a non-recursive search of the trie's nodes for the best place to insert the route, and do so.
-	visited := []*node{}
+	visited := make([]*node, 0, 128)
 	curNode := t.root
 	remainingRouteBits := routeBits
 


### PR DESCRIPTION
This commit belongs on main, not on the performance feature branch.