### PR TITLE
Test and fix bug

### DIFF
--- a/pkg/routesum/rstrie/rstrie.go
+++ b/pkg/routesum/rstrie/rstrie.go
@@ -57,7 +57,7 @@ func (n *node) insertRoute(parent **node, remainingRouteBits bitslice.BitSlice) 
 	if remainingRouteBitsLen <= curNodeBitsLen && bytes.HasPrefix(n.bits, remainingRouteBits) {
 		n.bits = remainingRouteBits
 		n.children = nil
-		return false
+		return true
 	}
 
 	if curNodeBitsLen <= remainingRouteBitsLen && bytes.HasPrefix(remainingRouteBits, n.bits) {

--- a/pkg/routesum/rstrie/rstrie_test.go
+++ b/pkg/routesum/rstrie/rstrie_test.go
@@ -145,6 +145,18 @@ func TestRSTrieInsertRoute(t *testing.T) { //nolint: funlen
 				children: nil,
 			}},
 		},
+		{
+			name: "completed subtries are simplified when new route covers current",
+			routes: []bitslice.BitSlice{
+				{0, 0},
+				{0, 1, 1},
+				{0, 1},
+			},
+			expected: &RSTrie{root: &node{
+				bits:     bitslice.BitSlice{0},
+				children: nil,
+			}},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
When we remove child nodes in an effort to simplify the current representation, we should return true so that the simplification process can continue up the trie until it is no longer needed. This test fails without the fix.