### PR TITLE
Test using a bit vector for storage instead of bytes

### DIFF
--- a/cmd/routesum/main.go
+++ b/cmd/routesum/main.go
@@ -32,7 +32,12 @@ func summarize(in io.Reader, out io.Writer) error {
 		}
 	}
 
-	for _, s := range rs.SummaryStrings() {
+	strs, err := rs.SummaryStrings()
+	if err != nil {
+		return fmt.Errorf("get strings: %w", err)
+	}
+
+	for _, s := range strs {
 		if _, err := out.Write([]byte(s + "\n")); err != nil {
 			return fmt.Errorf("write output: %w", err)
 		}

--- a/pkg/routesum/bitvector/bitvector.go
+++ b/pkg/routesum/bitvector/bitvector.go
@@ -1,0 +1,336 @@
+// Package bitvector implements a type and methods for creating and working with dynamically-sized,
+// bit-endian, immutable bit vectors.
+package bitvector
+
+import (
+	"errors"
+	"fmt"
+	"math/bits"
+	"net/netip"
+)
+
+// BitVector is a dynamically-sized, big-endian bit vector.
+type BitVector struct {
+	bits   []byte
+	length int
+}
+
+// New creates a BitVector from the given byte slice and length. Mostly for testing purposes.
+func New(bits []byte, length int) BitVector {
+	if bits == nil {
+		return BitVector{bits: nil, length: length}
+	}
+
+	newBits := make([]byte, len(bits))
+	copy(newBits, bits)
+	return BitVector{bits: newBits, length: length}
+}
+
+// NewFromIP creates a BitVector from a netip.Addr.
+func NewFromIP(ip netip.Addr) (BitVector, error) {
+	b, err := ip.MarshalBinary()
+	if err != nil {
+		return New(nil, 0), fmt.Errorf("marshal IP to binary: %w", err)
+	}
+
+	return New(b, ip.BitLen()), nil
+}
+
+// NewFromPrefix creates a BitVector from a netip.Prefix.
+func NewFromPrefix(prefix netip.Prefix) (BitVector, error) {
+	b, err := prefix.Addr().MarshalBinary()
+	if err != nil {
+		return New(nil, 0), fmt.Errorf("marshal prefix IP to binary: %w", err)
+	}
+
+	bv := New(b, prefix.Addr().BitLen())
+
+	// Shift off the host bits and return.
+	return bv.ShiftRight(prefix.Addr().BitLen() - prefix.Bits()), nil
+}
+
+// Len returns the number of bits in the BitVector.
+func (bv BitVector) Len() int {
+	return bv.length
+}
+
+// Clone makes a deep copy of a BitVector.
+func (bv BitVector) Clone() BitVector {
+	if bv.length == 0 {
+		return New(nil, 0)
+	}
+
+	numBytes := len(bv.bits)
+	newBits := make([]byte, numBytes)
+	copy(newBits, bv.bits)
+
+	return New(newBits, bv.length)
+}
+
+// ShiftRight returns a new BitVector containing a copy of the receiver's bits shifted to the right
+// n times.
+func (bv BitVector) ShiftRight(n int) BitVector {
+	// Are we shifting more bits than we have?
+	if n >= bv.length {
+		return New(nil, 0)
+	}
+
+	numBits := bv.length - n
+	numRequiredBytes, numWholeBytes, numRemainingBits := numBytesForBits(numBits)
+
+	newBits := make([]byte, numRequiredBytes)
+	copy(newBits, bv.bits)
+
+	// The final internal byte has bits that need zeroing out.
+	if numRemainingBits > 0 {
+		masks := map[int]byte{
+			1: 0b10000000,
+			2: 0b11000000,
+			3: 0b11100000,
+			4: 0b11110000,
+			5: 0b11111000,
+			6: 0b11111100,
+			7: 0b11111110,
+		}
+		newBits[numWholeBytes] &= masks[numRemainingBits]
+	}
+
+	return New(newBits, numBits)
+}
+
+// ShiftLeft returns a new BitVector containing a copy of the receiver's bits shifted to the left
+// n times.
+func (bv BitVector) ShiftLeft(n int) BitVector {
+	numBits := bv.length + n
+	numRequiredBytes, _, _ := numBytesForBits(numBits)
+
+	newBits := make([]byte, numRequiredBytes)
+	copy(newBits, bv.bits)
+
+	return New(newBits, numBits)
+}
+
+// HasPrefix determines if the receiver starts with the bits in the given BitVector.
+func (bv BitVector) HasPrefix(bv2 BitVector) bool {
+	if bv2.length > bv.length {
+		return false
+	}
+
+	// Compare whole bytes.
+	_, numWholeBytes, numRemainingBits := numBytesForBits(bv2.length)
+	for i := range numWholeBytes {
+		if bv.bits[i] != bv2.bits[i] {
+			return false
+		}
+	}
+
+	// If there's no remaining bits to compare, we're done.
+	if numRemainingBits == 0 {
+		return true
+	}
+
+	// Compare remaining bits.
+	mask := byteMaskOnesFromLeft(numRemainingBits)
+	return bv.bits[numWholeBytes]&mask == bv2.bits[numWholeBytes]&mask
+}
+
+// Prefix returns a BitVector containing a copy of the receiver's leading n bits.
+func (bv BitVector) Prefix(n int) BitVector {
+	return bv.ShiftRight(bv.length - n)
+}
+
+// At returns the value (0 or 1) of the requested bit of the receiver.
+func (bv BitVector) At(n int) int {
+	return bitValue(bv.bits[n>>3], n&7)
+}
+
+// bitValue returns the value of the byte's nth bit (0 or 1)
+func bitValue(b byte, n int) int {
+	return int(((b & (1 << (7 - n))) >> (7 - n)) & 1)
+}
+
+// SliceFrom returns a BitVector containing a copy of bits from the receiver starting at the given
+// bit.
+func (bv BitVector) SliceFrom(n int) BitVector {
+	numBits := bv.length - n
+	if numBits <= 0 {
+		return New(nil, 0)
+	}
+
+	numRequiredBytes, _, _ := numBytesForBits(numBits)
+	newBits := make([]byte, numRequiredBytes)
+
+	_, startingByte, bitOffset := numBytesForBits(n)
+	if bitOffset == 0 {
+		// If we're starting on a byte boundary, we have a simple process.
+		for i := range numRequiredBytes {
+			newBits[i] = bv.bits[i+startingByte]
+		}
+	} else {
+		// Otherwise, we're merging portions of two source bytes for each target byte.
+		copyBitsWithOffset(bv.bits[startingByte:], bitOffset, numBits, newBits)
+	}
+
+	return New(newBits, numBits)
+}
+
+func byteMaskOnesFromRight(n int) byte {
+	masks := map[int]byte{
+		0: 0b00000000,
+		1: 0b00000001,
+		2: 0b00000011,
+		3: 0b00000111,
+		4: 0b00001111,
+		5: 0b00011111,
+		6: 0b00111111,
+		7: 0b01111111,
+		8: 0b11111111,
+	}
+
+	return masks[n]
+}
+
+func byteMaskOnesFromLeft(n int) byte {
+	masks := map[int]byte{
+		0: 0b00000000,
+		1: 0b10000000,
+		2: 0b11000000,
+		3: 0b11100000,
+		4: 0b11110000,
+		5: 0b11111000,
+		6: 0b11111100,
+		7: 0b11111110,
+		8: 0b11111111,
+	}
+
+	return masks[n]
+}
+
+func numBytesForBits(numBits int) (int, int, int) {
+	numWholeBytes := numBits >> 3
+	numRemainingBits := numBits & 7
+
+	numRequiredBytes := numWholeBytes
+	if numRemainingBits > 0 {
+		numRequiredBytes++
+	}
+
+	return numRequiredBytes, numWholeBytes, numRemainingBits
+}
+
+// Append returns the concatenation of bv and bv2.
+func (bv BitVector) Append(bv2 BitVector) BitVector {
+	if bv.length == 0 {
+		return bv2.Clone()
+	}
+
+	if bv2.length == 0 {
+		return bv.Clone()
+	}
+
+	numBits := bv.length + bv2.length
+	numRequiredBytes, _, _ := numBytesForBits(numBits)
+	newBits := make([]byte, numRequiredBytes)
+
+	// First copy over bv.
+	for i := range len(bv.bits) {
+		newBits[i] = bv.bits[i]
+	}
+
+	// Then add bv2.
+	bitOffset := bv.length & 7
+	if bitOffset == 0 {
+		// We can just copy bytes from bv2
+		startingByte := len(bv.bits)
+		for i := range len(bv2.bits) {
+			newBits[i+startingByte] = bv2.bits[i]
+		}
+	} else {
+		// First we need to complete the last byte of newBits.
+		secondBitOffset := 8 - bitOffset
+		mask := byteMaskOnesFromLeft(secondBitOffset)
+		newBits[len(bv.bits)-1] |= (bv2.bits[0] & mask) >> bitOffset
+
+		// Next copy over the remainder of bv2.
+		if 8-bitOffset < bv2.length {
+			copyBitsWithOffset(bv2.bits, secondBitOffset, bv2.length-(secondBitOffset), newBits[len(bv.bits):])
+		}
+	}
+
+	return New(newBits, numBits)
+}
+
+// copyByteswithOffset copies numBits from source (offset by bitOffet bits) to target.
+// It panics if it's asked to copy more bits than are available.
+func copyBitsWithOffset(source []byte, bitOffset, numBits int, target []byte) {
+	// Create masks for the source lead and tail bytes
+	leadMask := byteMaskOnesFromRight(8 - bitOffset)
+	tailMask := byteMaskOnesFromLeft(bitOffset)
+	leadLShift := bitOffset
+	tailRShift := 8 - bitOffset
+
+	// Write bytes into target by merging source lead and tail bytes.
+	numBitsAvailable := len(source)*8 - bitOffset
+	numWholeBytes := numBitsAvailable >> 3
+	for i := range numWholeBytes {
+		target[i] = source[i]&leadMask<<leadLShift + source[i+1]&tailMask>>tailRShift
+	}
+
+	// There may be some final lead bits to copy over.
+	if numWholeBytes*8 < numBits {
+		target[numWholeBytes] = source[numWholeBytes] & leadMask << leadLShift
+	}
+}
+
+// CommonPrefixLen calculates the number of leading bits bv and bv2 have in common.
+func (bv BitVector) CommonPrefixLen(bv2 BitVector) int {
+	numComparableBits := min(bv.length, bv2.length)
+
+	// First compare whole bytes.
+	numComparableWholeBytes := numComparableBits >> 3
+	for i := range numComparableWholeBytes {
+		if x := bv.bits[i] ^ bv2.bits[i]; x != 0 {
+			return (i * 8) + bits.LeadingZeros8(x)
+		}
+	}
+
+	// Then compare the remaining bits.
+	numRemainingBits := numComparableBits & 7
+	if numRemainingBits == 0 {
+		return numComparableBits
+	}
+
+	mask := byteMaskOnesFromLeft(numRemainingBits)
+	if x := (bv.bits[numComparableWholeBytes] & mask) ^ (bv2.bits[numComparableWholeBytes] & mask); x != 0 {
+		return (numComparableWholeBytes * 8) + bits.LeadingZeros8(x)
+	}
+
+	return (numComparableWholeBytes * 8) + numRemainingBits
+}
+
+// ErrNotAnIP is returned when the bits in a BitVector cannot be represented as an IP address.
+var ErrNotAnIP = errors.New("unable to interpret BitVector as an IP")
+
+// ToIP returns a netip.Addr from the BitVector using the given number of bytes. (4 for IPv4, 16 for
+// IPv6).
+func (bv BitVector) ToIP(numBytes int) (netip.Addr, error) {
+	b := bv.ShiftLeft(numBytes*8 - bv.Len()).bits
+
+	ip, ok := netip.AddrFromSlice(b)
+	if !ok {
+		return netip.Addr{}, ErrNotAnIP
+	}
+
+	return ip, nil
+}
+
+// ToPrefix returns a netip.Prefix from the BitVector using the given number of bytes. (4 for IPv4,
+// 16 for IPv6).
+func (bv BitVector) ToPrefix(numBytes int) (netip.Prefix, error) {
+	ip, err := bv.ToIP(numBytes)
+	if err != nil {
+		return netip.Prefix{}, err
+	}
+
+	return netip.PrefixFrom(ip, bv.Len()), nil
+}

--- a/pkg/routesum/bitvector/bitvector_test.go
+++ b/pkg/routesum/bitvector/bitvector_test.go
@@ -1,0 +1,575 @@
+package bitvector
+
+import (
+	"maps"
+	"net/netip"
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInputOutputForIP(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      netip.Addr
+		expected BitVector
+	}{
+		{
+			name:     "IPv4 addr",
+			val:      netip.MustParseAddr("192.0.2.37"),
+			expected: New([]byte{192, 0, 2, 37}, 32),
+		},
+		{
+			name: "IPv6-embedded IPv4 addr",
+			val:  netip.MustParseAddr("::ffff:192.0.2.37"),
+			expected: New(
+				[]byte{
+					0, 0, 0, 0,
+					0, 0, 0, 0,
+					0, 0, 0xff, 0xff,
+					192, 0, 2, 37,
+				},
+				128,
+			),
+		},
+		{
+			name: "IPv6 addr",
+			val:  netip.MustParseAddr("2001:db8::1"),
+			expected: New(
+				[]byte{
+					0x20, 0x1, 0xd, 0xb8,
+					0, 0, 0, 0,
+					0, 0, 0, 0,
+					0, 0, 0, 1,
+				},
+				128,
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bv, err := NewFromIP(test.val)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, bv)
+
+			gotIP, err := bv.ToIP(test.val.BitLen() / 8)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.val, gotIP)
+		})
+	}
+}
+
+func TestInputOutputForPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      netip.Prefix
+		expected BitVector
+	}{
+		{
+			name:     "IPv4 prefix",
+			val:      netip.MustParsePrefix("192.0.2.0/28"),
+			expected: New([]byte{192, 0, 2, 0}, 28),
+		},
+		{
+			name: "IPv6-embedded IPv4 prefix",
+			val:  netip.MustParsePrefix("::ffff:192.0.2.0/127"),
+			expected: New(
+				[]byte{
+					0, 0, 0, 0,
+					0, 0, 0, 0,
+					0, 0, 0xff, 0xff,
+					192, 0, 2, 0,
+				},
+				127,
+			),
+		},
+		{
+			name:     "IPv6 prefix",
+			val:      netip.MustParsePrefix("2001:db8::/29"),
+			expected: New([]byte{0x20, 0x1, 0xd, 0xb8}, 29),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			bv, err := NewFromPrefix(test.val)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, bv)
+
+			gotPrefix, err := bv.ToPrefix(test.val.Addr().BitLen() / 8)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.val, gotPrefix)
+		})
+	}
+}
+
+func TestShiftRight(t *testing.T) { //nolint: funlen // we're testing a lot
+	tests := []struct {
+		name     string
+		bv       BitVector
+		numBits  int
+		expected BitVector
+	}{
+		{
+			name:     "identity",
+			bv:       New([]byte{0b11111111, 0b11110000}, 12),
+			numBits:  0,
+			expected: New([]byte{0b11111111, 0b11110000}, 12),
+		},
+		{
+			name:     "shift more than we have",
+			bv:       New([]byte{0b11111111, 0b11110000}, 12),
+			numBits:  12,
+			expected: New(nil, 0),
+		},
+		{
+			name:     "shift one bit",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  1,
+			expected: New([]byte{0b10101010, 0b10100000}, 11),
+		},
+		{
+			name:     "shift two bits",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  2,
+			expected: New([]byte{0b10101010, 0b10000000}, 10),
+		},
+		{
+			name:     "shift four bits, disappearing one byte",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  4,
+			expected: New([]byte{0b10101010}, 8),
+		},
+		{
+			name:     "shift a byte, no bits",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  8,
+			expected: New([]byte{0b10100000}, 4),
+		},
+		{
+			name:     "shift a byte and a bit",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  9,
+			expected: New([]byte{0b10100000}, 3),
+		},
+		{
+			name:     "mask off one bit",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  1,
+			expected: New([]byte{0b11111110}, 7),
+		},
+		{
+			name:     "mask off two bits",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  2,
+			expected: New([]byte{0b11111100}, 6),
+		},
+		{
+			name:     "mask off three bits",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  3,
+			expected: New([]byte{0b11111000}, 5),
+		},
+		{
+			name:     "mask off four bits",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  4,
+			expected: New([]byte{0b11110000}, 4),
+		},
+		{
+			name:     "mask off five bits",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  5,
+			expected: New([]byte{0b11100000}, 3),
+		},
+		{
+			name:     "mask off six bits",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  6,
+			expected: New([]byte{0b11000000}, 2),
+		},
+		{
+			name:     "mask off seven bits",
+			bv:       New([]byte{0b11111111}, 8),
+			numBits:  7,
+			expected: New([]byte{0b10000000}, 1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.bv.ShiftRight(test.numBits)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestShiftLeft(t *testing.T) {
+	tests := []struct {
+		name     string
+		bv       BitVector
+		numBits  int
+		expected BitVector
+	}{
+		{
+			name:     "identity",
+			bv:       New([]byte{0b11111111, 0b11110000}, 12),
+			numBits:  0,
+			expected: New([]byte{0b11111111, 0b11110000}, 12),
+		},
+		{
+			name:     "shift one bit",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  1,
+			expected: New([]byte{0b10101010, 0b10100000}, 13),
+		},
+		{
+			name:     "shift two bits",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  2,
+			expected: New([]byte{0b10101010, 0b10100000}, 14),
+		},
+		{
+			name:     "shift four bits, filling the last byte",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  4,
+			expected: New([]byte{0b10101010, 0b10100000}, 16),
+		},
+		{
+			name:     "shift a byte, no bits",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  8,
+			expected: New([]byte{0b10101010, 0b10100000, 0b00000000}, 20),
+		},
+		{
+			name:     "shift a byte and a bit",
+			bv:       New([]byte{0b10101010, 0b10100000}, 12),
+			numBits:  9,
+			expected: New([]byte{0b10101010, 0b10100000, 0b00000000}, 21),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.bv.ShiftLeft(test.numBits)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestHasPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		bv1      BitVector
+		bv2      BitVector
+		expected bool
+	}{
+		{
+			name:     "identity",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b11111111, 0b11110000}, 12),
+			expected: true,
+		},
+		{
+			name:     "shorter - same",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b11111111, 0b11100000}, 11),
+			expected: true,
+		},
+		{
+			name:     "shorter - not same on bits",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b11111111, 0b00000000}, 11),
+			expected: false,
+		},
+		{
+			name:     "shorter - not same on bytes",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b00010010, 0b00000000}, 11),
+			expected: false,
+		},
+		{
+			name:     "shorter - on byte boundary",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b11111111}, 8),
+			expected: true,
+		},
+		{
+			name:     "one byte shorter",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b11111110}, 7),
+			expected: true,
+		},
+		{
+			name:     "longer",
+			bv1:      New([]byte{0b11111111, 0b11110000}, 12),
+			bv2:      New([]byte{0b11111111, 0b11111000}, 13),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, test.bv1.HasPrefix(test.bv2))
+		})
+	}
+}
+
+func TestAt(t *testing.T) {
+	bv := New([]byte{192, 0, 2, 36}, 31)
+
+	expectedBits := []int{
+		1, 1, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 1, 0,
+		0, 0, 1, 0, 0, 1, 0,
+	}
+
+	assert.Equal(t, 31, bv.length)
+
+	for i := range 31 {
+		assert.Equal(t, expectedBits[i], bv.At(i), "bit "+strconv.Itoa(i))
+	}
+}
+
+func TestSliceFrom(t *testing.T) {
+	bv := New([]byte{0b10101010, 0b10101010, 0b10100000}, 20)
+
+	tests := map[int]BitVector{
+		0:  bv,
+		1:  New([]byte{0b01010101, 0b01010101, 0b01000000}, 19),
+		2:  New([]byte{0b10101010, 0b10101010, 0b10000000}, 18),
+		3:  New([]byte{0b01010101, 0b01010101, 0b00000000}, 17),
+		4:  New([]byte{0b10101010, 0b10101010}, 16),
+		5:  New([]byte{0b01010101, 0b01010100}, 15),
+		6:  New([]byte{0b10101010, 0b10101000}, 14),
+		7:  New([]byte{0b01010101, 0b01010000}, 13),
+		8:  New([]byte{0b10101010, 0b10100000}, 12),
+		9:  New([]byte{0b01010101, 0b01000000}, 11),
+		10: New([]byte{0b10101010, 0b10000000}, 10),
+		11: New([]byte{0b01010101, 0b00000000}, 9),
+		12: New([]byte{0b10101010}, 8),
+		13: New([]byte{0b01010100}, 7),
+		14: New([]byte{0b10101000}, 6),
+		15: New([]byte{0b01010000}, 5),
+		16: New([]byte{0b10100000}, 4),
+		17: New([]byte{0b01000000}, 3),
+		18: New([]byte{0b10000000}, 2),
+		19: New([]byte{0b00000000}, 1),
+		20: New(nil, 0),
+	}
+
+	sortedNumBits := slices.Collect(maps.Keys(tests))
+	slices.Sort(sortedNumBits)
+
+	for _, numBits := range sortedNumBits {
+		t.Run(strconv.Itoa(numBits)+" bits", func(t *testing.T) {
+			assert.Equal(t, tests[numBits], bv.SliceFrom(numBits))
+		})
+	}
+}
+
+func TestAppend(t *testing.T) { //nolint: funlen // We're testing a lot.
+	tests := []struct {
+		name               string
+		bv1, bv2, expected BitVector
+	}{
+		{
+			name:     "empty appended to empty",
+			bv1:      New(nil, 0),
+			bv2:      New(nil, 0),
+			expected: New(nil, 0),
+		},
+		{
+			name:     "empty appended to not empty",
+			bv1:      New(nil, 0),
+			bv2:      BitVector{bits: []byte{0b10101010, 0b10000000}, length: 10},
+			expected: BitVector{bits: []byte{0b10101010, 0b10000000}, length: 10},
+		},
+		{
+			name:     "not empty appended to empty",
+			bv1:      BitVector{bits: []byte{0b10101111}, length: 8},
+			bv2:      New(nil, 0),
+			expected: BitVector{bits: []byte{0b10101111}, length: 8},
+		},
+		{
+			name:     "some bits and some bits, result less than a byte",
+			bv1:      BitVector{bits: []byte{0b10100000}, length: 3},
+			bv2:      BitVector{bits: []byte{0b11000000}, length: 2},
+			expected: BitVector{bits: []byte{0b10111000}, length: 5},
+		},
+		{
+			name:     "some bits and some bits, result exactly a byte",
+			bv1:      BitVector{bits: []byte{0b10100000}, length: 3},
+			bv2:      BitVector{bits: []byte{0b10111000}, length: 5},
+			expected: BitVector{bits: []byte{0b10110111}, length: 8},
+		},
+		{
+			name:     "some bits and some bits, result more than a byte",
+			bv1:      BitVector{bits: []byte{0b10101010}, length: 7},
+			bv2:      BitVector{bits: []byte{0b10111000}, length: 5},
+			expected: BitVector{bits: []byte{0b10101011, 0b01110000}, length: 12},
+		},
+		{
+			name:     "some bits and a byte",
+			bv1:      BitVector{bits: []byte{0b10100000}, length: 3},
+			bv2:      BitVector{bits: []byte{0b01010101}, length: 8},
+			expected: BitVector{bits: []byte{0b10101010, 0b10100000}, length: 11},
+		},
+		{
+			name:     "some bits and a byte and some bits, resulting in a byte and some bits",
+			bv1:      BitVector{bits: []byte{0b10100000}, length: 3},
+			bv2:      BitVector{bits: []byte{0b01010101, 0b01110000}, length: 12},
+			expected: BitVector{bits: []byte{0b10101010, 0b10101110}, length: 15},
+		},
+		{
+			name:     "some bits and a byte and some bits, resulting in a two bytes",
+			bv1:      BitVector{bits: []byte{0b10100100}, length: 6},
+			bv2:      BitVector{bits: []byte{0b10111000, 0b10000000}, length: 10},
+			expected: BitVector{bits: []byte{0b10100110, 0b11100010}, length: 16},
+		},
+		{
+			name:     "some bits and some bytes",
+			bv1:      BitVector{bits: []byte{0b11010000}, length: 4},
+			bv2:      BitVector{bits: []byte{0b00100010, 0b00001000, 0b10000000}, length: 20},
+			expected: BitVector{bits: []byte{0b11010010, 0b00100000, 0b10001000}, length: 24},
+		},
+		{
+			name:     "a byte and some bits",
+			bv1:      BitVector{bits: []byte{0b01000101}, length: 8},
+			bv2:      BitVector{bits: []byte{0b10000000}, length: 2},
+			expected: BitVector{bits: []byte{0b01000101, 0b10000000}, length: 10},
+		},
+		{
+			name:     "a byte and a byte",
+			bv1:      BitVector{bits: []byte{0b01101100}, length: 8},
+			bv2:      BitVector{bits: []byte{0b00110101}, length: 8},
+			expected: BitVector{bits: []byte{0b01101100, 0b00110101}, length: 16},
+		},
+		{
+			name:     "a byte and some bytes and bits",
+			bv1:      BitVector{bits: []byte{0b10010001}, length: 8},
+			bv2:      BitVector{bits: []byte{0b01000111, 0b00110100, 0b11011110}, length: 23},
+			expected: BitVector{bits: []byte{0b10010001, 0b01000111, 0b00110100, 0b11011110}, length: 31},
+		},
+		{
+			name:     "a byte and some bits and some bits, result is less than two bytes",
+			bv1:      BitVector{bits: []byte{0b01111110, 0b01000000}, length: 10},
+			bv2:      BitVector{bits: []byte{0b00000000}, length: 3},
+			expected: BitVector{bits: []byte{0b01111110, 0b01000000}, length: 13},
+		},
+		{
+			name:     "a byte and some bits and some bits, result is two bytes",
+			bv1:      BitVector{bits: []byte{0b01111110, 0b01000000}, length: 10},
+			bv2:      BitVector{bits: []byte{0b01010100}, length: 6},
+			expected: BitVector{bits: []byte{0b01111110, 0b01010101}, length: 16},
+		},
+		{
+			name:     "a byte and some bits and some bits, result is more than two bytes",
+			bv1:      BitVector{bits: []byte{0b01111110, 0b01000000}, length: 10},
+			bv2:      BitVector{bits: []byte{0b00001110}, length: 7},
+			expected: BitVector{bits: []byte{0b01111110, 0b01000011, 0b10000000}, length: 17},
+		},
+		{
+			name:     "a byte and some bits and a byte",
+			bv1:      BitVector{bits: []byte{0b11001010, 0b10100000}, length: 11},
+			bv2:      BitVector{bits: []byte{0b00000110}, length: 8},
+			expected: BitVector{bits: []byte{0b11001010, 0b10100000, 0b11000000}, length: 19},
+		},
+		{
+			name:     "a byte and some bits and a byte and some bits, result is less than three bytes",
+			bv1:      BitVector{bits: []byte{0b00010110, 0b01000000}, length: 10},
+			bv2:      BitVector{bits: []byte{0b01100010, 0b11000000}, length: 11},
+			expected: BitVector{bits: []byte{0b00010110, 0b01011000, 0b10110000}, length: 21},
+		},
+		{
+			name:     "a byte and some bits and a byte and some bits, result is three bytes",
+			bv1:      BitVector{bits: []byte{0b10011111, 0b10000100}, length: 15},
+			bv2:      BitVector{bits: []byte{0b11010110, 0b00000000}, length: 9},
+			expected: BitVector{bits: []byte{0b10011111, 0b10000101, 0b10101100}, length: 24},
+		},
+		{
+			name:     "a byte and some bits and a byte and some bits, result is more than three bytes",
+			bv1:      BitVector{bits: []byte{0b00010110, 0b00110010}, length: 15},
+			bv2:      BitVector{bits: []byte{0b01100010, 0b11000000}, length: 14},
+			expected: BitVector{bits: []byte{0b00010110, 0b00110010, 0b11000101, 0b10000000}, length: 29},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.bv1.Append(test.bv2)
+			assert.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestCommonPrefixLen(t *testing.T) {
+	tests := []struct {
+		name     string
+		bv1      BitVector
+		bv2      BitVector
+		expected int
+	}{
+		{
+			name:     "nothing in common",
+			bv1:      New([]byte{0b11000000}, 2),
+			bv2:      New([]byte{0b00000000}, 2),
+			expected: 0,
+		},
+		{
+			name:     "a byte and a byte",
+			bv1:      New([]byte{0b11110001}, 8),
+			bv2:      New([]byte{0b11110010}, 8),
+			expected: 6,
+		},
+		{
+			name:     "some bits and a byte",
+			bv1:      New([]byte{0b11110000}, 4),
+			bv2:      New([]byte{0b11100111}, 8),
+			expected: 3,
+		},
+		{
+			name:     "some bits and a byte",
+			bv1:      New([]byte{0b11110000}, 4),
+			bv2:      New([]byte{0b11110111}, 8),
+			expected: 4,
+		},
+		{
+			name:     "differ before a byte boundary",
+			bv1:      New([]byte{0b00111000, 0b10111001, 0b01000010}, 24),
+			bv2:      New([]byte{0b00111000, 0b10111000, 0b01000010}, 24),
+			expected: 15,
+		},
+		{
+			name:     "differ on a byte boundary",
+			bv1:      New([]byte{0b00111000, 0b10111001, 0b11000010}, 24),
+			bv2:      New([]byte{0b00111000, 0b10111001, 0b01000010}, 24),
+			expected: 16,
+		},
+		{
+			name:     "differ after a byte boundary",
+			bv1:      New([]byte{0b00111000, 0b10111001, 0b01000010}, 24),
+			bv2:      New([]byte{0b00111000, 0b10111001, 0b00100010}, 24),
+			expected: 17,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(
+				t,
+				test.expected,
+				test.bv1.CommonPrefixLen(test.bv2),
+			)
+		})
+	}
+}

--- a/pkg/routesum/routesum_test.go
+++ b/pkg/routesum/routesum_test.go
@@ -26,7 +26,10 @@ func TestStrings(t *testing.T) { //nolint: funlen
 			if assert.Error(t, err) {
 				assert.Regexp(t, invalidIPErr, err.Error())
 			}
-			assert.Equal(t, []string{}, rs.SummaryStrings(), "nothing was added")
+
+			strs, err := rs.SummaryStrings()
+			require.NoError(t, err)
+			assert.Equal(t, []string{}, strs, "nothing was added")
 		})
 	}
 
@@ -48,7 +51,11 @@ func TestStrings(t *testing.T) { //nolint: funlen
 			if assert.Error(t, err) {
 				assert.Regexp(t, invalidNetErr, err.Error())
 			}
-			assert.Equal(t, []string{}, rs.SummaryStrings(), "nothing was added")
+
+			strs, err := rs.SummaryStrings()
+			require.NoError(t, err)
+
+			assert.Equal(t, []string{}, strs, "nothing was added")
 		})
 	}
 
@@ -70,8 +77,8 @@ func TestStrings(t *testing.T) { //nolint: funlen
 			expected: []string{
 				"192.0.2.0",
 				"198.51.100.0/24",
-				"::ffff:c000:200",
-				"::ffff:c633:6400/120",
+				"::ffff:192.0.2.0",
+				"::ffff:198.51.100.0/120",
 				"2001:db8::",
 				"2001:db8:1::/48",
 			},
@@ -88,7 +95,7 @@ func TestStrings(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0",
-				"::ffff:c000:200",
+				"::ffff:192.0.2.0",
 				"2001:db8::",
 			},
 		},
@@ -110,7 +117,11 @@ func TestStrings(t *testing.T) { //nolint: funlen
 				err := rs.InsertFromString(str)
 				require.NoError(t, err)
 			}
-			assert.Equal(t, test.expected, rs.SummaryStrings(), "summarized as expected")
+
+			strs, err := rs.SummaryStrings()
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, strs, "summarized as expected")
 		})
 	}
 }
@@ -140,8 +151,8 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			expected: []string{
 				"192.0.2.0",
 				"198.51.100.0/31",
-				"::ffff:c000:200",
-				"::ffff:c633:6400/127",
+				"::ffff:192.0.2.0",
+				"::ffff:198.51.100.0/127",
 				"2001:db8::",
 				"2001:db8::1:0/127",
 			},
@@ -158,7 +169,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0/26",
-				"::ffff:c000:200/120",
+				"::ffff:192.0.2.0/120",
 				"2001:db8::/120",
 			},
 		},
@@ -174,7 +185,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0/31",
-				"::ffff:c000:200/127",
+				"::ffff:192.0.2.0/127",
 				"2001:db8::/127",
 			},
 		},
@@ -196,7 +207,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0/30",
-				"::ffff:c000:200/126",
+				"::ffff:192.0.2.0/126",
 				"2001:db8::/126",
 			},
 		},
@@ -321,7 +332,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0/24",
-				"::ffff:c000:200/120",
+				"::ffff:192.0.2.0/120",
 				"2001:db8::/32",
 			},
 		},
@@ -360,12 +371,12 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 				"198.51.100.2/31",
 				"198.51.100.4/30",
 				"198.51.100.8/31",
-				"::ffff:c000:201",
-				"::ffff:c000:202/127",
-				"::ffff:c000:204",
-				"::ffff:c633:6402/127",
-				"::ffff:c633:6404/126",
-				"::ffff:c633:6408/127",
+				"::ffff:192.0.2.1",
+				"::ffff:192.0.2.2/127",
+				"::ffff:192.0.2.4",
+				"::ffff:198.51.100.2/127",
+				"::ffff:198.51.100.4/126",
+				"::ffff:198.51.100.8/127",
 				"2001:db8::1",
 				"2001:db8::2/127",
 				"2001:db8::4",
@@ -389,7 +400,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0/31",
-				"::ffff:c000:200/127",
+				"::ffff:192.0.2.0/127",
 				"2001:db8::/127",
 			},
 		},
@@ -399,7 +410,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 				"::ffff:192.0.2.0",
 			},
 			expected: []string{
-				"::ffff:c000:200",
+				"::ffff:192.0.2.0",
 			},
 		},
 		{
@@ -410,7 +421,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0",
-				"::ffff:c000:200",
+				"::ffff:192.0.2.0",
 			},
 		},
 		{
@@ -422,7 +433,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0",
-				"::ffff:c000:200",
+				"::ffff:192.0.2.0",
 				"2001:db8::",
 			},
 		},
@@ -438,7 +449,7 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 			},
 			expected: []string{
 				"192.0.2.0",
-				"::ffff:c000:200",
+				"::ffff:192.0.2.0",
 				"2001:db8::",
 			},
 		},
@@ -451,7 +462,11 @@ func TestSummarize(t *testing.T) { //nolint: funlen
 				err := rs.InsertFromString(str)
 				require.NoError(t, err)
 			}
-			assert.Equal(t, test.expected, rs.SummaryStrings(), "got expected summary")
+
+			strs, err := rs.SummaryStrings()
+			require.NoError(t, err)
+
+			assert.Equal(t, test.expected, strs, "got expected summary")
 		})
 	}
 }


### PR DESCRIPTION
In the bitslice-based implementation, bits are stored in `[]byte`s, with each byte in the slice storing either a `0` or a `1`. Each bitslice is therefore taking up 7 times more space than necessary.

In this branch we try implementing a vector/slice of bits, where bits are still stored in `[]byte`s, but a byte holds 8 bits.

Preliminary results show that the bitslice-based implementation, while massively inefficient in its storage, is faster than the bit vector approach, by almost 2 orders of magnitude.