### PR TITLE
rstrie and routesum have iterator output methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.4.0
+
+* Add an iter.Seq output method to rstrie
+* Deprecate rstrie.Contents in favor of the iterator method
+* Add an iter.Seq output method to routesum
+* Deprecate routesum.SummaryStrings in favor of the iterator method
+* Prepare rstrie for concurrency
+
 ## 0.3.0 (2025-08-17)
 
 * Replace inet.af with net/netip, which removes the `unsafe` dependency

--- a/cmd/routesum/main.go
+++ b/cmd/routesum/main.go
@@ -32,7 +32,7 @@ func summarize(in io.Reader, out io.Writer) error {
 		}
 	}
 
-	for _, s := range rs.SummaryStrings() {
+	for s := range rs.Each() {
 		if _, err := out.Write([]byte(s + "\n")); err != nil {
 			return fmt.Errorf("write output: %w", err)
 		}

--- a/pkg/routesum/routesum.go
+++ b/pkg/routesum/routesum.go
@@ -3,7 +3,9 @@ package routesum
 
 import (
 	"fmt"
+	"iter"
 	"net/netip"
+	"slices"
 	"strings"
 
 	"github.com/PatrickCronin/routesum/pkg/routesum/bitslice"
@@ -98,32 +100,44 @@ func ipBitsForIP(ip netip.Addr) (bitslice.BitSlice, error) {
 }
 
 // SummaryStrings returns a summary of all received routes as a string slice.
+// Deprecated: Each() is preferred.
 func (rs *RouteSum) SummaryStrings() []string {
-	strs := []string{}
+	return slices.Collect(rs.Each())
+}
 
-	for bits := range rs.ipv4.Each() {
-		ip := ipv4FromBits(bits)
+// Each returns an iterator that returns each IP or prefix stored.
+func (rs *RouteSum) Each() iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for bits := range rs.ipv4.Each() {
+			ip := ipv4FromBits(bits)
 
-		if len(bits) == 8*4 {
-			strs = append(strs, ip.String())
-		} else {
-			prefix := netip.PrefixFrom(ip, len(bits))
-			strs = append(strs, prefix.String())
+			if len(bits) == 8*4 {
+				if !yield(ip.String()) {
+					return
+				}
+			} else {
+				prefix := netip.PrefixFrom(ip, len(bits))
+				if !yield(prefix.String()) {
+					return
+				}
+			}
+		}
+
+		for bits := range rs.ipv6.Each() {
+			ip := ipv6FromBits(bits)
+
+			if len(bits) == 8*16 {
+				if !yield(ip.String()) {
+					return
+				}
+			} else {
+				prefix := netip.PrefixFrom(ip, len(bits))
+				if !yield(prefix.String()) {
+					return
+				}
+			}
 		}
 	}
-
-	for bits := range rs.ipv6.Each() {
-		ip := ipv6FromBits(bits)
-
-		if len(bits) == 8*16 {
-			strs = append(strs, ip.String())
-		} else {
-			prefix := netip.PrefixFrom(ip, len(bits))
-			strs = append(strs, prefix.String())
-		}
-	}
-
-	return strs
 }
 
 func ipv4FromBits(bits bitslice.BitSlice) netip.Addr {

--- a/pkg/routesum/routesum.go
+++ b/pkg/routesum/routesum.go
@@ -101,8 +101,7 @@ func ipBitsForIP(ip netip.Addr) (bitslice.BitSlice, error) {
 func (rs *RouteSum) SummaryStrings() []string {
 	strs := []string{}
 
-	ipv4BitSlices := rs.ipv4.Contents()
-	for _, bits := range ipv4BitSlices {
+	for bits := range rs.ipv4.Each() {
 		ip := ipv4FromBits(bits)
 
 		if len(bits) == 8*4 {
@@ -113,8 +112,7 @@ func (rs *RouteSum) SummaryStrings() []string {
 		}
 	}
 
-	ipv6BitSlices := rs.ipv6.Contents()
-	for _, bits := range ipv6BitSlices {
+	for bits := range rs.ipv6.Each() {
 		ip := ipv6FromBits(bits)
 
 		if len(bits) == 8*16 {

--- a/pkg/routesum/routesum_test.go
+++ b/pkg/routesum/routesum_test.go
@@ -26,7 +26,7 @@ func TestStrings(t *testing.T) { //nolint: funlen
 			if assert.Error(t, err) {
 				assert.Regexp(t, invalidIPErr, err.Error())
 			}
-			assert.Equal(t, []string{}, rs.SummaryStrings(), "nothing was added")
+			assert.Equal(t, []string(nil), rs.SummaryStrings(), "nothing was added")
 		})
 	}
 
@@ -48,7 +48,7 @@ func TestStrings(t *testing.T) { //nolint: funlen
 			if assert.Error(t, err) {
 				assert.Regexp(t, invalidNetErr, err.Error())
 			}
-			assert.Equal(t, []string{}, rs.SummaryStrings(), "nothing was added")
+			assert.Equal(t, []string(nil), rs.SummaryStrings(), "nothing was added")
 		})
 	}
 


### PR DESCRIPTION
Instead of filling a slice with all the items gathered, and then returning it all in one big piece, let's add iterator methods to reduce memory requirements for output purposes.