### PR TITLE
Linter updates

### DIFF
--- a/cmd/routesum/main.go
+++ b/cmd/routesum/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	if err := summarize(os.Stdin, os.Stdout); err != nil {
-		fmt.Fprintf(os.Stderr, "summarize: %s\n", err.Error()) //nolint: gosec
+		fmt.Fprintf(os.Stderr, "summarize: %s\n", err.Error())
 		os.Exit(1)
 	}
 }

--- a/pkg/routesum/rstrie/rstrie.go
+++ b/pkg/routesum/rstrie/rstrie.go
@@ -185,7 +185,7 @@ func (t *RSTrie) Each() iter.Seq[bitslice.BitSlice] {
 		for remainingSteps.Len() > 0 {
 			step := remainingSteps.Remove(remainingSteps.Front()).(traversalStep)
 
-			stepRouteBits := bitslice.BitSlice{}
+			stepRouteBits := make(bitslice.BitSlice, 0, len(step.precedingRouteBits)+len(step.n.bits))
 			stepRouteBits = append(stepRouteBits, step.precedingRouteBits...)
 			stepRouteBits = append(stepRouteBits, step.n.bits...)
 


### PR DESCRIPTION
An automated golangci-lint run found a couple linter errors. We address them.