### PR TITLE
No-lint some new linter failures

### DIFF
--- a/pkg/routesum/routesum_test.go
+++ b/pkg/routesum/routesum_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+//nolint:goconst // The make-up of each IP used is more important than the fact that some are popular across tests.
 func TestStrings(t *testing.T) { //nolint: funlen
 	// Summarization logic is tested in TestSummarize.
 
@@ -115,6 +116,7 @@ func TestStrings(t *testing.T) { //nolint: funlen
 	}
 }
 
+//nolint:goconst // The make-up of each IP used is more important than the fact that some are popular across tests.
 func TestSummarize(t *testing.T) { //nolint: funlen
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Updates to golangci-lint have caused a go-const lint to be report in tests. Looking at the reported lints, I'd rather continue using the IPs written out then giving them names, as the make-up of each IP is semantically important to the test -- in fact the make-up of each IP is exactly what's under test.